### PR TITLE
fix: update copyright year in tauri configuration

### DIFF
--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
 	"bundle": {
 		"active": false,
 		"category": "DeveloperTool",
-		"copyright": "Copyright © 2023-2024 GitButler. All rights reserved.",
+		"copyright": "Copyright © 2023-2025 GitButler. All rights reserved.",
 		"createUpdaterArtifacts": "v1Compatible",
 		"targets": [
 			"app",


### PR DESCRIPTION
Updates the copyright year in the tauri configuration file
to reflect the current year, ensuring compliance with
intellectual property standards.